### PR TITLE
feature: support more variety of playlist files

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,5 +30,5 @@ function m3u8(playlist) {
  * @return {boolean}
  */
 function is_url(url) {
-  return (typeof url == 'string') && (url.startsWith('http://') || url.startsWith('https://'))
+  return (typeof url == 'string') && (url.startsWith('http://') || url.startsWith('https://') || url.includes('.m3u8'))
 }


### PR DESCRIPTION
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:BANDWIDTH=2800000,RESOLUTION=1280x720
1280x720/video.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080
1920x1080/video.m3u8
```

This is a common format of a `playlist.m3u8` file where you don't find any `http://` or `https://` into the url section. So, if you want to parse this kind of playlist file, then I've added the support for it by checking if the line contains `.m3u8` or not to detect if the line is an url.